### PR TITLE
Upgrade to the latest latest version of o-tracking

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@financial-times/o-grid": "^5.0.0",
-    "@financial-times/o-tracking": "^2.0.0",
+    "@financial-times/o-tracking": "^2.0.3",
     "@financial-times/o-viewport": "^4.0.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
On CI we have some apps that are getting 2.0.2, which has a bug where it tries to call bind on an object.