### PR TITLE
Swap `Time To Interactive` with `First Input Delay`

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ if (flags.get('realUserMonitoringForPerformance')) {
 	nTracking.trackers.realUserMonitoringForPerformance();
 }
 ```
-<div><img width="50%" src="https://user-images.githubusercontent.com/224547/71410882-f2b50980-263e-11ea-86f2-f7e986fc9fad.png" /></div>
+<div><img width="50%" src="https://user-images.githubusercontent.com/224547/71587880-665f8680-2b17-11ea-83c9-466d0c50ec08.png" /></div>
 
 _Above: Real-user-monitoring performance metrics are sent to spoor-api._ 
 

--- a/package.json
+++ b/package.json
@@ -33,10 +33,10 @@
     "node": ">=8.16.0"
   },
   "dependencies": {
-    "tti-polyfill": "^0.2.2",
     "@financial-times/o-grid": "^5.0.0",
     "@financial-times/o-tracking": "^2.0.3",
-    "@financial-times/o-viewport": "^4.0.0"
+    "@financial-times/o-viewport": "^4.0.0",
+    "first-input-delay": "^0.1.3"
   },
   "peerDependencies": {
     "react": "^16.9.0"

--- a/secret-squirrel.js
+++ b/secret-squirrel.js
@@ -8,7 +8,7 @@ module.exports = {
 	strings: {
 		deny: [],
 		denyOverrides: [
-			'f2b50980-263e-11ea-86f2-f7e986fc9fad' // README.md:57
+			'665f8680-2b17-11ea-83c9-466d0c50ec08' // README.md:51
 		]
 	}
 };

--- a/src/client/trackers/real-user-monitoring-for-performance.js
+++ b/src/client/trackers/real-user-monitoring-for-performance.js
@@ -1,4 +1,3 @@
-import 'first-input-delay';
 import { broadcast } from '../broadcast';
 import { userIsInCohort } from '../utils/userIsInCohort';
 
@@ -6,7 +5,10 @@ export const realUserMonitoringForPerformance = () => {
 	const cohortPercent = 5;
 	if (!userIsInCohort(cohortPercent)) return;
 
-	// For browser compatibility @see: https://mdn.github.io/dom-examples/performance-apis/perf-api-support.html
+	// For `PerformanceLongTaskTiming` browser compatibility, @see: https://mdn.github.io/dom-examples/performance-apis/perf-api-support.html
+	// `perfMetrics` is added to `window` scope by the first-input-delay code.
+	// @see: https://github.com/GoogleChromeLabs/first-input-delay/blob/master/src/first-input-delay.js#L170
+	// The perfMetrics <script> is added to the document <head> server side, via src/server/components/RealUserMonitoringForPerformance.jsx
 	if (!'PerformanceLongTaskTiming' in window || !'perfMetrics' in window) return;
 
 	// @see: https://web.dev/lcp/#how-to-measure-lcp (largest-contentful-paint)

--- a/src/client/trackers/real-user-monitoring-for-performance.js
+++ b/src/client/trackers/real-user-monitoring-for-performance.js
@@ -1,4 +1,4 @@
-import ttiPolyfill from 'tti-polyfill';
+import 'first-input-delay';
 import { broadcast } from '../broadcast';
 import { userIsInCohort } from '../utils/userIsInCohort';
 
@@ -7,7 +7,7 @@ export const realUserMonitoringForPerformance = () => {
 	if (!userIsInCohort(cohortPercent)) return;
 
 	// For browser compatibility @see: https://mdn.github.io/dom-examples/performance-apis/perf-api-support.html
-	if (!'PerformanceLongTaskTiming' in window || !'ttiPolyfill' in window) return;
+	if (!'PerformanceLongTaskTiming' in window || !'perfMetrics' in window) return;
 
 	// @see: https://web.dev/lcp/#how-to-measure-lcp (largest-contentful-paint)
 	let largestContentfulPaint;
@@ -18,10 +18,16 @@ export const realUserMonitoringForPerformance = () => {
 	});
 	lcpPerformanceObserver.observe({type: 'largest-contentful-paint', buffered: true});
 
-	ttiPolyfill.getFirstConsistentlyInteractive().then(timeToInteractive => {
+	/**
+	 * Use the 'First Input Delay (FID)' metric as the event that triggers the tracking broadcast
+	 *
+	 * FID is the delay that the user experiences when they first try to interact with the page.
+	 * @see: https://github.com/GoogleChromeLabs/first-input-delay#usage
+	 */
+	perfMetrics.onFirstInputDelay(firstInputDelay => { // eslint-disable-line no-undef
 
 		// Disconnect the observer once it no longer needs to observe the performance data
-		// @SEE: https://w3c.github.io/performance-timeline/#the-performanceobserver-interface
+		// @see: https://w3c.github.io/performance-timeline/#the-performanceobserver-interface
 		lcpPerformanceObserver.disconnect();
 
 		const navigation = performance.getEntriesByType('navigation')[0];
@@ -42,7 +48,7 @@ export const realUserMonitoringForPerformance = () => {
 				domInteractive: Math.round(domInteractive),
 				domComplete: Math.round(domComplete),
 				largestContentfulPaint: Math.round(largestContentfulPaint),
-				timeToInteractive: Math.round(timeToInteractive),
+				firstInputDelay: Math.round(firstInputDelay),
 			};
 
 			console.log(context); // eslint-disable-line no-console

--- a/src/client/trackers/real-user-monitoring-for-performance.js
+++ b/src/client/trackers/real-user-monitoring-for-performance.js
@@ -54,7 +54,7 @@ export const realUserMonitoringForPerformance = () => {
 			broadcast('oTracking.event', data);
 		}
 		catch (error) {
-			console.error(error); // eslint-disable-line no-console
+			console.error('Could not track web-peformance metrics:', error); // eslint-disable-line no-console
 		}
 	});
 };

--- a/src/server/components/RealUserMonitoringForPerformance.jsx
+++ b/src/server/components/RealUserMonitoringForPerformance.jsx
@@ -3,12 +3,10 @@ import React from 'react';
 // @see src/client/trackers/real-user-monitoring-for-performance.js for the code that depends on this <script>
 export const RealUserMonitoringForPerformance = () => {
 	return (
-		<React.Fragment>
 			<script
 				dangerouslySetInnerHTML={{
 					__html: `!function(n,e){var t,o,i,c=[],f={passive:!0,capture:!0},r=new Date,a="pointerup",u="pointercancel";function p(n,c){t||(t=c,o=n,i=new Date,w(e),s())}function s(){o>=0&&o<i-r&&(c.forEach(function(n){n(o,t)}),c=[])}function l(t){if(t.cancelable){var o=(t.timeStamp>1e12?new Date:performance.now())-t.timeStamp;"pointerdown"==t.type?function(t,o){function i(){p(t,o),r()}function c(){r()}function r(){e(a,i,f),e(u,c,f)}n(a,i,f),n(u,c,f)}(o,t):p(o,t)}}function w(n){["click","mousedown","keydown","touchstart","pointerdown"].forEach(function(e){n(e,l,f)})}w(n),self.perfMetrics=self.perfMetrics||{},self.perfMetrics.onFirstInputDelay=function(n){c.push(n),s()}}(addEventListener,removeEventListener);`
 				}}
 			/>
-		</React.Fragment>
 	);
 }

--- a/src/server/components/RealUserMonitoringForPerformance.jsx
+++ b/src/server/components/RealUserMonitoringForPerformance.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+// @see src/client/trackers/real-user-monitoring-for-performance.js for the code that depends on this <script>
+export const RealUserMonitoringForPerformance = () => {
+	return (
+		<React.Fragment>
+			<script
+				dangerouslySetInnerHTML={{
+					__html: `!function(n,e){var t,o,i,c=[],f={passive:!0,capture:!0},r=new Date,a="pointerup",u="pointercancel";function p(n,c){t||(t=c,o=n,i=new Date,w(e),s())}function s(){o>=0&&o<i-r&&(c.forEach(function(n){n(o,t)}),c=[])}function l(t){if(t.cancelable){var o=(t.timeStamp>1e12?new Date:performance.now())-t.timeStamp;"pointerdown"==t.type?function(t,o){function i(){p(t,o),r()}function c(){r()}function r(){e(a,i,f),e(u,c,f)}n(a,i,f),n(u,c,f)}(o,t):p(o,t)}}function w(n){["click","mousedown","keydown","touchstart","pointerdown"].forEach(function(e){n(e,l,f)})}w(n),self.perfMetrics=self.perfMetrics||{},self.perfMetrics.onFirstInputDelay=function(n){c.push(n),s()}}(addEventListener,removeEventListener);`
+				}}
+			/>
+		</React.Fragment>
+	);
+}

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -1,1 +1,2 @@
 export * from './components/CoreTracking.jsx';
+export * from './components/RealUserMonitoringForPerformance.jsx';


### PR DESCRIPTION
# UPDATE

I propose that this PR is cancelled in favour of https://github.com/Financial-Times/n-tracking/pull/32

______________________________________
Todo

 - [x] Refactor this into a server-side component to enable adding JS into the document `<head>`
 - [ ] Update the README

Resolves https://github.com/Financial-Times/n-tracking/issues/28

![image](https://user-images.githubusercontent.com/224547/71587880-665f8680-2b17-11ea-83c9-466d0c50ec08.png)

_Above: The `firstInputDelay` is the time in milliseconds that the user had to wait for the page to respond after they attempted to interact with it._

### Please Note

- The metrics are broadcast when the user triggers an input event.
- That event is likely to be a click event. (Scroll events are not considered "input", but "animation".)
- If the click event is on a link, then there's a chance the page will navigate away before the spoor network request is sent (or received).
- If we find that we're not getting the volume of data we expect, then look into this issue.
- At that point, consider utilising the solution for click events in `o-tracking`:
https://github.com/Financial-Times/o-tracking/blob/master/src/javascript/events/click.js#L77 

### Further reading

>Due to the expected variance in FID values, it's critical that when reporting on FID you look at the distribution of values and focus on the higher percentiles. In fact, we recommend specifically focusing on the 99th percentile, as that will correspond to the particularly bad first experiences users are having with your site. And it will show you the areas that need the most improvement.

https://developers.google.com/web/updates/2018/05/first-input-delay#analyzing_and_reporting_on_fid_data