### PR TITLE
Use Perfume.js for Real User Monitoring of Performance Metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ if (flags.get('realUserMonitoringForPerformance')) {
 	nTracking.trackers.realUserMonitoringForPerformance();
 }
 ```
-<div><img width="50%" src="https://user-images.githubusercontent.com/224547/71410882-f2b50980-263e-11ea-86f2-f7e986fc9fad.png" /></div>
+<div><img width="70%" src="https://user-images.githubusercontent.com/224547/71625733-4c8a7600-2be1-11ea-975b-b0b53c9cfe89.png" /></div>
 
 _Above: Real-user-monitoring performance metrics are sent to spoor-api._ 
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ if (flags.get('realUserMonitoringForPerformance')) {
 	nTracking.trackers.realUserMonitoringForPerformance();
 }
 ```
-<div><img width="70%" src="https://user-images.githubusercontent.com/224547/71625733-4c8a7600-2be1-11ea-975b-b0b53c9cfe89.png" /></div>
+<div><img width="70%" src="https://user-images.githubusercontent.com/224547/71626767-c709c480-2be6-11ea-91a5-506972a3b4d7.png" /></div>
 
 _Above: Real-user-monitoring performance metrics are sent to spoor-api._ 
 

--- a/package.json
+++ b/package.json
@@ -33,10 +33,10 @@
     "node": ">=8.16.0"
   },
   "dependencies": {
-    "tti-polyfill": "^0.2.2",
     "@financial-times/o-grid": "^5.0.0",
     "@financial-times/o-tracking": "^2.0.3",
-    "@financial-times/o-viewport": "^4.0.0"
+    "@financial-times/o-viewport": "^4.0.0",
+    "perfume.js": "^4.6.0"
   },
   "peerDependencies": {
     "react": "^16.9.0"

--- a/secret-squirrel.js
+++ b/secret-squirrel.js
@@ -8,7 +8,7 @@ module.exports = {
 	strings: {
 		deny: [],
 		denyOverrides: [
-			'4c8a7600-2be1-11ea-975b-b0b53c9cfe89' // README.md:51
+			'c709c480-2be6-11ea-91a5-506972a3b4d7' // README.md:51
 		]
 	}
 };

--- a/secret-squirrel.js
+++ b/secret-squirrel.js
@@ -8,7 +8,7 @@ module.exports = {
 	strings: {
 		deny: [],
 		denyOverrides: [
-			'f2b50980-263e-11ea-86f2-f7e986fc9fad' // README.md:57
+			'4c8a7600-2be1-11ea-975b-b0b53c9cfe89' // README.md:51
 		]
 	}
 };

--- a/src/client/trackers/real-user-monitoring-for-performance.js
+++ b/src/client/trackers/real-user-monitoring-for-performance.js
@@ -24,7 +24,14 @@ const requiredMetrics = [
 ];
 
 const cohortPercent = 5;
+
 export const realUserMonitoringForPerformance = () => {
+
+	// Check browser support.
+	// @see https://developer.mozilla.org/en-US/docs/Web/API/PerformanceLongTaskTiming
+	if (!'PerformanceLongTaskTiming' in window) return;
+
+	// Gather metrics for only a cohort of users.
 	if (!userIsInCohort(cohortPercent)) return;
 
 	const navigation = performance.getEntriesByType('navigation')[0];

--- a/src/client/trackers/real-user-monitoring-for-performance.js
+++ b/src/client/trackers/real-user-monitoring-for-performance.js
@@ -1,24 +1,24 @@
-import Perfume from 'perfume.js'
-import { broadcast } from '../broadcast'
-import { userIsInCohort } from '../utils/userIsInCohort'
+import Perfume from 'perfume.js';
+import { broadcast } from '../broadcast';
+import { userIsInCohort } from '../utils/userIsInCohort';
 
-const cohortPercent = 5
+const cohortPercent = 5;
 export const realUserMonitoringForPerformance = () => {
-	if (!userIsInCohort(cohortPercent)) return
+	if (!userIsInCohort(cohortPercent)) return;
 
-	const navigation = performance.getEntriesByType('navigation')[0]
-	const { type, domInteractive, domComplete } = navigation
+	const navigation = performance.getEntriesByType('navigation')[0];
+	const { type, domInteractive, domComplete } = navigation;
 
 	// Proceed only if the page load event is a "navigate".
 	// @see: https://developer.mozilla.org/en-US/docs/Web/API/PerformanceNavigationTiming/type
-	if (type !== 'navigate') return
+	if (type !== 'navigate') return;
 
 	const context = {
 		action: 'performance',
 		category: 'page',
 		domInteractive: Math.round(domInteractive),
 		domComplete: Math.round(domComplete),
-	}
+	};
 
 	/**
 	 * analyticsTracker()
@@ -27,30 +27,30 @@ export const realUserMonitoringForPerformance = () => {
 	 * The "final" event should be `firstInputDelay`, which is triggered by any "input" event (most likely to be a click.)
 	 * Once all the metrics are present, it fires a broadcast() to the Spoor API.
 	 */
-	let hasAlreadyBroadcast = false
+	let hasAlreadyBroadcast = false;
 	const analyticsTracker = (({ metricName, duration, data }) => {
-		if (hasAlreadyBroadcast) return
+		if (hasAlreadyBroadcast) return;
 
 		if (duration) {
 			// Metrics with "duration":
 			// firstPaint, firstContentfulPaint, firstInputDelay and largestContentfulPaint
-			context[metricName] = Math.round(duration)
+			context[metricName] = Math.round(duration);
 		}
 		else if (metricName === 'navigationTiming') {
-			context.timeToFirstByte = Math.round(data.timeToFirstByte)
+			context.timeToFirstByte = Math.round(data.timeToFirstByte);
 		}
 
 		// Broadcast only if all the metrics are present
 		const contextContainsAllRequiredMetrics = [
 			'domInteractive', 'domComplete', 'timeToFirstByte', 'firstPaint', 'firstContentfulPaint', 'firstInputDelay'
-		].every(metric => !isNaN(context[metric]))
+		].every(metric => !isNaN(context[metric]));
 
 		if (contextContainsAllRequiredMetrics) {
-			console.log({performanceMetrics:context}) // eslint-disable-line no-console
-			broadcast('oTracking.event', context)
-			hasAlreadyBroadcast = true
+			console.log({performanceMetrics:context}); // eslint-disable-line no-console
+			broadcast('oTracking.event', context);
+			hasAlreadyBroadcast = true;
 		}
-	})
+	});
 
 	// Perfume.js is a web performance package.
 	// @see https://zizzamia.github.io/perfume/#/default-options/
@@ -62,6 +62,6 @@ export const realUserMonitoringForPerformance = () => {
 		firstInputDelay: true,
 		largestContentfulPaint: true,
 		navigationTiming: true,
-	}
-	const perfume = new Perfume(options)
-}
+	};
+	new Perfume(options);
+};

--- a/src/client/trackers/real-user-monitoring-for-performance.js
+++ b/src/client/trackers/real-user-monitoring-for-performance.js
@@ -42,7 +42,7 @@ export const realUserMonitoringForPerformance = () => {
 
 		// Broadcast only if all the metrics are present
 		const contextContainsAllRequiredMetrics = [
-			'domInteractive', 'domComplete', 'timeToFirstByte', 'firstPaint', 'firstContentfulPaint', 'firstInputDelay'
+			'domInteractive', 'domComplete', 'timeToFirstByte', 'firstPaint', 'largestContentfulPaint', 'firstInputDelay'
 		].every(metric => !isNaN(context[metric]));
 
 		if (contextContainsAllRequiredMetrics) {
@@ -58,7 +58,7 @@ export const realUserMonitoringForPerformance = () => {
 		analyticsTracker,
 		logging: false,
 		firstPaint: true,
-		firstContentfulPaint: true,
+		largestContentfulPaint: true,
 		firstInputDelay: true,
 		largestContentfulPaint: true,
 		navigationTiming: true,

--- a/src/client/trackers/real-user-monitoring-for-performance.js
+++ b/src/client/trackers/real-user-monitoring-for-performance.js
@@ -1,60 +1,67 @@
-import ttiPolyfill from 'tti-polyfill';
-import { broadcast } from '../broadcast';
-import { userIsInCohort } from '../utils/userIsInCohort';
+import Perfume from 'perfume.js'
+import { broadcast } from '../broadcast'
+import { userIsInCohort } from '../utils/userIsInCohort'
 
+const cohortPercent = 5
 export const realUserMonitoringForPerformance = () => {
-	const cohortPercent = 5;
-	if (!userIsInCohort(cohortPercent)) return;
+	if (!userIsInCohort(cohortPercent)) return
 
-	// For browser compatibility @see: https://mdn.github.io/dom-examples/performance-apis/perf-api-support.html
-	if (!'PerformanceLongTaskTiming' in window || !'ttiPolyfill' in window) return;
+	const navigation = performance.getEntriesByType('navigation')[0]
+	const { type, domInteractive, domComplete } = navigation
 
-	// @see: https://web.dev/lcp/#how-to-measure-lcp (largest-contentful-paint)
-	let largestContentfulPaint;
-	const lcpPerformanceObserver = new PerformanceObserver((entryList) => {
-		const entries = entryList.getEntries();
-		const lastEntry = entries[entries.length - 1];
-		largestContentfulPaint = lastEntry.renderTime || lastEntry.loadTime;
-	});
-	lcpPerformanceObserver.observe({type: 'largest-contentful-paint', buffered: true});
+	// Proceed only if the page load event is a "navigate".
+	// @see: https://developer.mozilla.org/en-US/docs/Web/API/PerformanceNavigationTiming/type
+	if (type !== 'navigate') return
 
-	ttiPolyfill.getFirstConsistentlyInteractive().then(timeToInteractive => {
+	const context = {
+		action: 'performance',
+		category: 'page',
+		domInteractive: Math.round(domInteractive),
+		domComplete: Math.round(domComplete),
+	}
 
-		// Disconnect the observer once it no longer needs to observe the performance data
-		// @SEE: https://w3c.github.io/performance-timeline/#the-performanceobserver-interface
-		lcpPerformanceObserver.disconnect();
+	/**
+	 * analyticsTracker()
+	 *
+	 * This function is called every time one of the performance events occurs.
+	 * The "final" event should be `firstInputDelay`, which is triggered by any "input" event (most likely to be a click.)
+	 * Once all the metrics are present, it fires a broadcast() to the Spoor API.
+	 */
+	let hasAlreadyBroadcast = false
+	const analyticsTracker = (({ metricName, duration, data }) => {
+		if (hasAlreadyBroadcast) return
 
-		const navigation = performance.getEntriesByType('navigation')[0];
-		const { type, domInteractive, domComplete, responseStart, requestStart } = navigation;
-
-		// Proceed only if the page load event is a "navigate".
-		// @see: https://developer.mozilla.org/en-US/docs/Web/API/PerformanceNavigationTiming/type
-		if (type !== 'navigate') return;
-
-		try {
-			const timeToFirstByte = responseStart - requestStart;
-			const firstPaint = performance.getEntriesByName('first-paint')[0].startTime;
-			const firstContentfulPaint = performance.getEntriesByName('first-contentful-paint')[0].startTime;
-			const context = {
-				firstPaint: Math.round(firstPaint),
-				firstContentfulPaint: Math.round(firstContentfulPaint),
-				timeToFirstByte: Math.round(timeToFirstByte),
-				domInteractive: Math.round(domInteractive),
-				domComplete: Math.round(domComplete),
-				largestContentfulPaint: Math.round(largestContentfulPaint),
-				timeToInteractive: Math.round(timeToInteractive),
-			};
-
-			console.log(context); // eslint-disable-line no-console
-			const data = {
-				action: 'performance',
-				category: 'page',
-				...context
-			};
-			broadcast('oTracking.event', data);
+		if (duration) {
+			// Metrics with "duration":
+			// firstPaint, firstContentfulPaint, firstInputDelay and largestContentfulPaint
+			context[metricName] = Math.round(duration)
 		}
-		catch (error) {
-			console.error(error); // eslint-disable-line no-console
+		else if (metricName === 'navigationTiming') {
+			context.timeToFirstByte = Math.round(data.timeToFirstByte)
 		}
-	});
-};
+
+		// Broadcast only if all the metrics are present
+		const contextContainsAllRequiredMetrics = [
+			'domInteractive', 'domComplete', 'timeToFirstByte', 'firstPaint', 'firstContentfulPaint', 'firstInputDelay'
+		].every(metric => !isNaN(context[metric]))
+
+		if (contextContainsAllRequiredMetrics) {
+			console.log({performanceMetrics:context}) // eslint-disable-line no-console
+			broadcast('oTracking.event', context)
+			hasAlreadyBroadcast = true
+		}
+	})
+
+	// Perfume.js is a web performance package.
+	// @see https://zizzamia.github.io/perfume/#/default-options/
+	const options = {
+		analyticsTracker,
+		logging: false,
+		firstPaint: true,
+		firstContentfulPaint: true,
+		firstInputDelay: true,
+		largestContentfulPaint: true,
+		navigationTiming: true,
+	}
+	const perfume = new Perfume(options)
+}


### PR DESCRIPTION
@see: http://perfumejs.com/

- Perfume.js uses typescript and has good unit tests. 
- No `<head>` polyfill script snippets are required.
- Resolves https://github.com/Financial-Times/n-tracking/issues/28

### Todo 
 - [x] Update the README

![image](https://user-images.githubusercontent.com/224547/71626767-c709c480-2be6-11ea-91a5-506972a3b4d7.png)

_Above: The `firstInputDelay` is the time in milliseconds that the user had to wait for the page to respond after they attempted to interact with it._

*To use this in your FT.com application, call `nTracking.trackers.realUserMonitoringForPerformance()`. For example:*

```JavaScript
// client/main.js

if (flags.get('realUserMonitoringForPerformance')) {
  nTracking.trackers.realUserMonitoringForPerformance();
}
```

The flag for this feature is `realUserMonitoringForPerformance`.
![image](https://user-images.githubusercontent.com/224547/71410357-e465ee00-263c-11ea-8ab5-211aad388b0a.png)

### Please Note

- The metrics are broadcast when the user triggers an input event.
- That event is likely to be a click event. (Scroll events are not considered "input", but "animation".)
- If the click event is on a link, then there's a chance the page will navigate away before the spoor network request is sent (or received).
- If we find that we're not getting the volume of data we expect, then look into this issue.
- At that point, consider utilising the solution for click events in `o-tracking`:
https://github.com/Financial-Times/o-tracking/blob/master/src/javascript/events/click.js#L77 

### Further reading

>Due to the expected variance in FID values, it's critical that when reporting on FID you look at the distribution of values and focus on the higher percentiles. In fact, we recommend specifically focusing on the 99th percentile, as that will correspond to the particularly bad first experiences users are having with your site. And it will show you the areas that need the most improvement.

https://developers.google.com/web/updates/2018/05/first-input-delay#analyzing_and_reporting_on_fid_data