### PR TITLE
Call documentReady function in realUserMonitoringForPerformance

### DIFF
--- a/src/client/trackers/realUserMonitoringForPerformance.js
+++ b/src/client/trackers/realUserMonitoringForPerformance.js
@@ -39,7 +39,7 @@ export const realUserMonitoringForPerformance = () => {
 
 	const context = {};
 
-	documentReady.then(() => {
+	documentReady().then(() => {
 		// <https://developer.mozilla.org/en-US/docs/Web/API/PerformanceNavigationTiming/domInteractive>
 		context.domInteractive = Math.round(navigation.domInteractive);
 		// <https://developer.mozilla.org/en-US/docs/Web/API/PerformanceNavigationTiming/domComplete>


### PR DESCRIPTION
If this line is reached it will currently error with:

```
Uncaught (in promise) TypeError: documentReady.then is not a function
	at Object.realUserMonitoringForPerformance (browser.js?91a3:181)
	at eval (main.js?2034:35)
```

However, in any case this code is intended to be overwritten by this PR: https://github.com/Financial-Times/n-tracking/pull/40.