### PR TITLE
turn on the Beacon API transport mechanism within o-tracking

### DIFF
--- a/src/client/__test__/index.spec.js
+++ b/src/client/__test__/index.spec.js
@@ -34,7 +34,7 @@ describe('src/index', () => {
 			expect(oTracking.init).toHaveBeenCalledWith(
 				expect.objectContaining({
 					server: SPOOR_API_INGEST_URL,
-					useSendBeacon: false
+					useSendBeacon: true
 				})
 			);
 		});

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -18,8 +18,10 @@ export function init ({ appContext, extraContext, pageViewContext }) {
 			...extraContext
 		}),
 		user: getUserData(),
-		// TODO: This should be safe to enable, find out why it hasn't been
-		useSendBeacon: false
+		// Using the Beacon API ensures that no tracking event data is lost 
+		// when the document is being unloaded, which happens when navigating 
+		// to a different page.
+		useSendBeacon: true
 	};
 
 	oTracking.init(options);

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -18,8 +18,8 @@ export function init ({ appContext, extraContext, pageViewContext }) {
 			...extraContext
 		}),
 		user: getUserData(),
-		// Using the Beacon API ensures that no tracking event data is lost 
-		// when the document is being unloaded, which happens when navigating 
+		// Using the Beacon API ensures that no tracking event data is lost
+		// when the document is being unloaded, which happens when navigating
 		// to a different page.
 		useSendBeacon: true
 	};


### PR DESCRIPTION
Using the Beacon API ensures that no tracking event data is lost when the document is being unloaded, which happens when navigating to a different page.

cc @chrisbrownuk