### PR TITLE
Use appropriate CircleCI Docker Node image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ references:
   container_config_node: &container_config_node
     working_directory: ~/project/build
     docker:
-      - image: circleci/node:12-browsers
+      - image: circleci/node:12
 
   workspace_root: &workspace_root ~/project
 


### PR DESCRIPTION
Switch from `circleci/node:12-browsers` to `circleci/node:12` as the former is not required for this repo.<br/><br/>This PR was created using a nori script 🍙<br/><br/>_Nori is a command-line application for managing changes across multiple (usually Github) repositories._