### PR TITLE
CPP-442 Upgrade GitHub repos from master to main

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,9 +29,9 @@ references:
     restore_cache:
       <<: *npm_cache_keys
 
-  filters_only_master: &filters_only_master
+  filters_only_main: &filters_only_main
     branches:
-      only: master
+      only: main
 
   filters_ignore_tags: &filters_ignore_tags
     tags:
@@ -163,7 +163,7 @@ workflows:
       - schedule:
           cron: "0 0 * * *"
           filters:
-            <<: *filters_only_master
+            <<: *filters_only_main
     jobs:
       - build:
           context: next-nightly-build

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Property          | Type   | Required | Description
 `extraContext`    | Object | No       | Additional data describing the current page which will be appended to all captured events.
 `pageViewContext` | Object | No       | Additional data to append to the page view event only
 
-[FT.com App Context]: https://github.com/Financial-Times/dotcom-page-kit/blob/master/packages/dotcom-server-app-context/schema.md
+[FT.com App Context]: https://github.com/Financial-Times/dotcom-page-kit/blob/HEAD/packages/dotcom-server-app-context/schema.md
 
 
 ## Automatically inferred data

--- a/src/server/lib/formatAppContext.js
+++ b/src/server/lib/formatAppContext.js
@@ -1,5 +1,5 @@
 // For a list of all the properties available see the app context schema:
-// <https://github.com/Financial-Times/dotcom-page-kit/blob/master/packages/dotcom-server-app-context/schema.md>
+// <https://github.com/Financial-Times/dotcom-page-kit/blob/HEAD/packages/dotcom-server-app-context/schema.md>
 export default function formatAppContext (appContext = {}) {
 	return {
 		name: appContext.appName || 'unknown',


### PR DESCRIPTION
[Ticket CPP-442 Upgrade GitHub repos from `master` to `main`](https://financialtimes.atlassian.net/browse/CPP-442)<br/><br/>As an organisation we are moving away from the usage of `master` as a central branch and switching it to `main`, this is to avoid using unnecessary language that can be offensive. This PR is for making those changes. <br/><br/>This PR was created using a nori script<br/><br/>_Nori is a command-line application for managing changes across multiple (usually Github) repositories._