### PR TITLE
Updating perfume / Real User Monitoring

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "jest": "^25.0.0",
     "jest-environment-jsdom-fifteen": "^1.0.0",
     "jsdom": "^15.1.0",
-    "perfume.js": "^4.6.0",
+    "perfume.js": "^6.3.0",
     "react": "^16.9.0",
     "rollup": "^1.31.0",
     "rollup-plugin-babel": "^4.3.3",

--- a/src/client/trackers/realUserMonitoringForPerformance.js
+++ b/src/client/trackers/realUserMonitoringForPerformance.js
@@ -9,10 +9,10 @@ const requiredMetrics = [
 	'domInteractive',
 	'domComplete',
 	'timeToFirstByte',
-	'cumulativeLayoutShift',
 	'firstPaint',
 	'largestContentfulPaint',
-	'firstInputDelay'
+	'firstInputDelay',
+	'cumulativeLayoutShift'
 ];
 
 const samplePercentage = 5;
@@ -32,10 +32,10 @@ export const realUserMonitoringForPerformance = () => {
 	// Gather metrics for only a cohort of users.
 	if (!seedIsInSample(spoorId, samplePercentage)) return;
 
-	const navigation = performance.getEntriesByType('navigation')[0];
-
 	// Proceed only if the page load event is a "navigate".
 	// @see: https://developer.mozilla.org/en-US/docs/Web/API/PerformanceNavigationTiming/type
+	// When testing, you will need to open a new browser window and paste the URL in i.e. simply reloading the page will not work.
+	const navigation = performance.getEntriesByType('navigation')[0];
 	if (navigation.type !== 'navigate') return;
 
 	const context = {};
@@ -56,19 +56,24 @@ export const realUserMonitoringForPerformance = () => {
 	 */
 	let hasAlreadyBroadcast = false;
 
-	const analyticsTracker = (({ metricName, duration, data }) => {
+	const analyticsTracker = (({ metricName, data}) => {
 		if (hasAlreadyBroadcast) return;
 
-		if (duration) {
-			// Metrics with "duration":
-			// firstPaint, firstContentfulPaint, firstInputDelay and largestContentfulPaint
-			context[metricName] = Math.round(duration);
-		}
-
-		// Metrics with "data":
-		// navigationTiming, networkInformation
-		if (metricName === 'navigationTiming') {
-			context.timeToFirstByte = Math.round(data.timeToFirstByte);
+		if (metricName === 'fid') {
+			context.firstInputDelay = Math.round(data);
+		} else if (metricName === 'lcp') {
+			//This fires at two points - when FID is fired and when the page's lifecycle is changed to 'hidden'
+			//this records the first, TODO: determine if that is the 'best' point or not.
+			context.largestContentfulPaint = Math.round(data);
+		} else if (metricName === 'ttfb') {
+			context.timeToFirstByte = Math.round(data);
+		} else if (metricName === 'fp') {
+			context.firstPaint = Math.round(data);
+		} else if (metricName === 'cls') {
+			//This fires at two points - when FID is fired and when the page's lifecycle is changed to 'hidden'
+			//this records the first, TODO: determine if that is the 'best' point or not.
+			//CLS is below 1 (ideally below 0.1) so am not rounding this data point
+			context.cumulativeLayoutShift = data;
 		}
 
 		if (isContextComplete(context)) {

--- a/src/client/trackers/realUserMonitoringForPerformance.js
+++ b/src/client/trackers/realUserMonitoringForPerformance.js
@@ -9,6 +9,7 @@ const requiredMetrics = [
 	'domInteractive',
 	'domComplete',
 	'timeToFirstByte',
+	'cumulativeLayoutShift',
 	'firstPaint',
 	'largestContentfulPaint',
 	'firstInputDelay'


### PR DESCRIPTION
Our RUM data isn't collecting fully, this change should update the dependency + add Cumulative Layout Shift (CLS) to our data.

A package called perfume does our real user monitoring.  I want to know how our Chrome Web Vital measurements look in the real world i.e. via RUM data.  We aren't currently collecting Cumulative Layout Shift (CLS).  Without all 3 main metrics we are flying somewhat blind.

So I've updated perfume (as it was a really old version) and added in CLS.

Separately, I have asked the data team if they [think this change could break anything](https://financialtimes.slack.com/archives/CQG2PHZ1A/p1639503485427100?thread_ts=1634810002.002000&cid=CQG2PHZ1A).  If not I hope to merge it on Friday.