### PR TITLE
Updating rum data behaviour

### DIFF
--- a/src/client/trackers/realUserMonitoringForPerformance.js
+++ b/src/client/trackers/realUserMonitoringForPerformance.js
@@ -84,7 +84,7 @@ export const realUserMonitoringForPerformance = () => {
 			broadcast('oTracking.event', {
 				action: 'performance',
 				category: 'page',
-				context
+				...context
 			});
 
 			hasAlreadyBroadcast = true;

--- a/src/client/trackers/realUserMonitoringForPerformance.js
+++ b/src/client/trackers/realUserMonitoringForPerformance.js
@@ -17,7 +17,7 @@ const requiredMetrics = [
 	'totalBlockingTime'
 ];
 
-const samplePercentage = 5;
+const samplePercentage = 10;
 
 const isContextComplete = (context) => {
 	return requiredMetrics.every((metric) => typeof context[metric] === 'number');


### PR DESCRIPTION
## Removing Nested Context from Sent Data

Removing `context` key from data passed to o-tracking as this was causing data to be double nested.

Data sent via o-tracking before:  `context.context.rumVariableName`

Data that will send via o-tracking after change:  `context.rumVariableName`

The nesting was adding unnecessary complexity on the data team side.  See line in [o-tracking](https://github.com/Financial-Times/origami/blob/main/libraries/o-tracking/src/javascript/events/custom.js#L48) to see where nested `context.context` was coming from.

## Increasing Sample Size
Increasing sample size from 5% of users to 10% to increase quantity of RUM data gathered.