### PR TITLE
Adds URL to the context for page performance events

### DIFF
--- a/src/client/trackers/realUserMonitoringForPerformance.js
+++ b/src/client/trackers/realUserMonitoringForPerformance.js
@@ -78,6 +78,8 @@ export const realUserMonitoringForPerformance = () => {
 			context.totalBlockingTime = Math.round(data);
 		}
 
+		context.url = window.document.location.href || null;
+
 		if (isContextComplete(context)) {
 			console.log({ performanceMetrics: context }); // eslint-disable-line no-console
 


### PR DESCRIPTION
This data isn't available by default in the data pipeline so it needs to be in the context of the source event.

Existing analytics work matches this up on the back end.  However, to use this data from within Amplitude (and to be able to split by page / see the information for a specific page) this data point needs to be sent with the initial reporting payload.

This is copied from how it is done elsewhere for collecting click info etc.