### PR TITLE
CPP-890 update config for nightly scheduled-pipelines

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,6 +136,11 @@ workflows:
   version: 2
 
   build-test:
+    when:
+      not:
+        equal:
+          - scheduled_pipeline
+          - << pipeline.trigger_source >>
     jobs:
       - build:
           filters:
@@ -153,6 +158,11 @@ workflows:
               node-version: [ "16.14", "14.19" ]
 
   build-test-publish:
+    when:
+      not:
+        equal:
+          - scheduled_pipeline
+          - << pipeline.trigger_source >>
     jobs:
       - build:
           filters:
@@ -178,6 +188,11 @@ workflows:
             - test-v16.14
 
   renovate-nori-build-test:
+    when:
+      not:
+        equal:
+          - scheduled_pipeline
+          - << pipeline.trigger_source >>
     jobs:
       - waiting-for-approval:
           type: approval
@@ -199,11 +214,14 @@ workflows:
               node-version: [ "16.14", "14.19" ]
 
   nightly:
-    triggers:
-      - schedule:
-          cron: "0 0 * * *"
-          filters:
-            <<: *filters_only_main
+    when:
+      and:
+        - equal:
+            - scheduled_pipeline
+            - << pipeline.trigger_source >>
+        - equal:
+            - nightly
+            - << pipeline.schedule.name >>
     jobs:
       - build:
           context: next-nightly-build


### PR DESCRIPTION
Applies workflows filtering to your circleci/config.yml, so that the nightly workflow runs with the scheduled trigger, and other workflows won't run with the scheduled trigger.