### PR TITLE
Switch from Perfume.js to Google Web Vitals

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-shrinkwrap=false

--- a/docs/real-user-performance-metrics.md
+++ b/docs/real-user-performance-metrics.md
@@ -38,7 +38,7 @@ if (flags.get('realUserMonitoringForPerformance')) {
 }
 ```
 
-This script will detect whether the browser supports performance timing, sample users based on their allocated Spoor ID, and initialise [Perfume.js](https://www.npmjs.com/package/perfume.js) to calculate the metrics.
+This script will detect whether the browser supports performance timing, sample users based on their allocated Spoor ID, and initialise [web-vitals](https://www.npmjs.com/package/web-vitals) to calculate the metrics.
 
 Once all metrics have been collected a `page:performance` event will be triggered and sent to Spoor.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
         "@financial-times/o-grid": "^5.0.0",
         "@financial-times/o-tracking": "^4.0.0",
         "@financial-times/o-viewport": "^4.0.0",
-        "ready-state": "^2.0.5"
+        "ready-state": "^2.0.5",
+        "web-vitals": "^3.0.0"
       },
       "devDependencies": {
         "@babel/core": "^7.5.5",
@@ -28,18 +29,17 @@
         "jest": "^25.0.0",
         "jest-environment-jsdom-fifteen": "^1.0.0",
         "jsdom": "^15.1.0",
-        "perfume.js": "^4.6.0",
         "react": "^16.9.0",
         "rollup": "^1.31.0",
         "rollup-plugin-babel": "^4.3.3",
         "seed-random": "^2.2.0"
       },
       "engines": {
-        "node": "12.x",
+        "node": "14.x || 16.x",
         "npm": "7.x || 8.x"
       },
       "peerDependencies": {
-        "react": "^16.9.0"
+        "react": ">=16.9.0 <19.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -11636,15 +11636,6 @@
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
       "dev": true
     },
-    "node_modules/perfume.js": {
-      "version": "4.8.1",
-      "resolved": "https://registry.npmjs.org/perfume.js/-/perfume.js-4.8.1.tgz",
-      "integrity": "sha512-tnQ4UxvgB4gPuqsbvwq0cPcesypWm+YGWKyzeewr3jbG6ojGJcSn1VGxub4wqYz69cxIxjJj+SKwtsSFiPpqYQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
     "node_modules/picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
@@ -15011,6 +15002,11 @@
       "dependencies": {
         "makeerror": "1.0.12"
       }
+    },
+    "node_modules/web-vitals": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-3.0.1.tgz",
+      "integrity": "sha512-n8LgBynM5BU4C8ZMiTWPu6zbv31AfPnuNXEjWClvPWD5g8h2WkcecR0EtAiQaiMcj1iG0LADyHndR+MKYu5Zog=="
     },
     "node_modules/webidl-conversions": {
       "version": "4.0.2",
@@ -24229,12 +24225,6 @@
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
       "dev": true
     },
-    "perfume.js": {
-      "version": "4.8.1",
-      "resolved": "https://registry.npmjs.org/perfume.js/-/perfume.js-4.8.1.tgz",
-      "integrity": "sha512-tnQ4UxvgB4gPuqsbvwq0cPcesypWm+YGWKyzeewr3jbG6ojGJcSn1VGxub4wqYz69cxIxjJj+SKwtsSFiPpqYQ==",
-      "dev": true
-    },
     "picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
@@ -26866,6 +26856,11 @@
       "requires": {
         "makeerror": "1.0.12"
       }
+    },
+    "web-vitals": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-3.0.1.tgz",
+      "integrity": "sha512-n8LgBynM5BU4C8ZMiTWPu6zbv31AfPnuNXEjWClvPWD5g8h2WkcecR0EtAiQaiMcj1iG0LADyHndR+MKYu5Zog=="
     },
     "webidl-conversions": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "jest": "^25.0.0",
     "jest-environment-jsdom-fifteen": "^1.0.0",
     "jsdom": "^15.1.0",
-    "perfume.js": "^6.3.0",
     "react": "^16.9.0",
     "rollup": "^1.31.0",
     "rollup-plugin-babel": "^4.3.3",
@@ -40,7 +39,8 @@
     "@financial-times/o-grid": "^5.0.0",
     "@financial-times/o-tracking": "^4.0.0",
     "@financial-times/o-viewport": "^4.0.0",
-    "ready-state": "^2.0.5"
+    "ready-state": "^2.0.5",
+    "web-vitals": "^3.0.0"
   },
   "peerDependencies": {
     "react": ">=16.9.0 <19.0.0"

--- a/src/client/trackers/__test__/__snapshots__/realUserMonitoring.spec.js.snap
+++ b/src/client/trackers/__test__/__snapshots__/realUserMonitoring.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src/client/trackers/realUserMonitoringForPerformance .realUserMonitoringForPerformance() analyticsTracker(options) when all metrics are sent broadcasts an o-tracking event with the formatted metrics data 1`] = `
+exports[`src/client/trackers/realUserMonitoringForPerformance .realUserMonitoringForPerformance() recordMetric(metric) when all metrics are sent broadcasts an o-tracking event with the formatted metrics data 1`] = `
 Object {
   "action": "performance",
   "category": "page",
@@ -9,10 +9,8 @@ Object {
   "domInteractive": 679,
   "firstContentfulPaint": 14,
   "firstInputDelay": 14,
-  "firstPaint": 14,
   "largestContentfulPaint": 14,
   "timeToFirstByte": 14,
-  "totalBlockingTime": 14,
   "url": "http://localhost/",
 }
 `;

--- a/src/client/trackers/__test__/__snapshots__/realUserMonitoring.spec.js.snap
+++ b/src/client/trackers/__test__/__snapshots__/realUserMonitoring.spec.js.snap
@@ -4,7 +4,7 @@ exports[`src/client/trackers/realUserMonitoringForPerformance .realUserMonitorin
 Object {
   "action": "performance",
   "category": "page",
-  "cumulativeLayoutShift": 13.7,
+  "cumulativeLayoutShift": 13.7654,
   "domComplete": 123,
   "domInteractive": 679,
   "firstContentfulPaint": 14,

--- a/src/client/trackers/__test__/realUserMonitoring.spec.js
+++ b/src/client/trackers/__test__/realUserMonitoring.spec.js
@@ -68,10 +68,11 @@ describe('src/client/trackers/realUserMonitoringForPerformance', () => {
 		});
 
 		it('uses the same handler for all metrics', () => {
-			expect(onCLS.mock.calls[0][0] === onFCP.mock.calls[0][0]).toBe(true);
-			expect(onCLS.mock.calls[0][0] === onFID.mock.calls[0][0]).toBe(true);
-			expect(onCLS.mock.calls[0][0] === onLCP.mock.calls[0][0]).toBe(true);
-			expect(onCLS.mock.calls[0][0] === onTTFB.mock.calls[0][0]).toBe(true);
+			const clsHandler = onCLS.mock.calls[0][0];
+			expect(onFCP.mock.calls[0][0]).toStrictEqual(clsHandler);
+			expect(onFID.mock.calls[0][0]).toStrictEqual(clsHandler);
+			expect(onLCP.mock.calls[0][0]).toStrictEqual(clsHandler);
+			expect(onTTFB.mock.calls[0][0]).toStrictEqual(clsHandler);
 		});
 
 		describe('recordMetric(metric)', () => {

--- a/src/client/trackers/__test__/realUserMonitoring.spec.js
+++ b/src/client/trackers/__test__/realUserMonitoring.spec.js
@@ -107,7 +107,7 @@ describe('src/client/trackers/realUserMonitoringForPerformance', () => {
 					recordMetric({ name: 'LCP', value: 13.7 });
 					recordMetric({ name: 'TTFB', value: 13.7 });
 					recordMetric({ name: 'FCP', value: 13.7 });
-					recordMetric({ name: 'CLS', value: 13.7 });
+					recordMetric({ name: 'CLS', value: 13.76539 });
 				});
 
 				it('broadcasts an o-tracking event with the formatted metrics data', () => {
@@ -115,6 +115,12 @@ describe('src/client/trackers/realUserMonitoringForPerformance', () => {
 					const broadcastArguments = broadcast.mock.calls[0];
 					expect(broadcastArguments[0]).toBe('oTracking.event');
 					expect(broadcastArguments[1]).toMatchSnapshot();
+				});
+
+				it('rounds the CLS metric to four decimal places', () => {
+					expect(broadcast).toHaveBeenCalledTimes(1);
+					const {cumulativeLayoutShift} = broadcast.mock.calls[0][1];
+					expect(cumulativeLayoutShift).toBe(13.7654);
 				});
 
 				describe('when any one of the metrics are sent a second time', () => {

--- a/src/client/trackers/__test__/realUserMonitoring.spec.js
+++ b/src/client/trackers/__test__/realUserMonitoring.spec.js
@@ -24,7 +24,7 @@ jest.mock('../../broadcast', () => ({
 }));
 import {broadcast} from '../../broadcast';
 
-// Mock Perfume
+// Mock web-vitals
 jest.mock('web-vitals', () => ({
 	onCLS: jest.fn(),
 	onFCP: jest.fn(),
@@ -42,10 +42,6 @@ Performance.prototype.getEntriesByType = jest.fn().mockReturnValue([
 		domInteractive: 678.90
 	}
 ]);
-
-// Mock requestIdleCallback so we can capture metrics
-// sent by Perfume
-window.requestIdleCallback = jest.fn();
 
 import {realUserMonitoringForPerformance} from '../realUserMonitoringForPerformance';
 

--- a/src/client/trackers/__test__/realUserMonitoring.spec.js
+++ b/src/client/trackers/__test__/realUserMonitoring.spec.js
@@ -60,6 +60,7 @@ describe('src/client/trackers/realUserMonitoringForPerformance', () => {
 		it('listens to metrics with the web-vitals package', () => {
 			expect(onCLS).toHaveBeenCalledTimes(1);
 			expect(typeof onCLS.mock.calls[0][0]).toBe('function');
+			expect(onCLS.mock.calls[0][1]).toEqual({ reportAllChanges: true });
 			expect(onFCP).toHaveBeenCalledTimes(1);
 			expect(typeof onFCP.mock.calls[0][0]).toBe('function');
 			expect(onFID).toHaveBeenCalledTimes(1);

--- a/src/client/trackers/__test__/realUserMonitoring.spec.js
+++ b/src/client/trackers/__test__/realUserMonitoring.spec.js
@@ -25,10 +25,14 @@ jest.mock('../../broadcast', () => ({
 import {broadcast} from '../../broadcast';
 
 // Mock Perfume
-jest.mock('perfume.js', () => {
-	return jest.fn();
-});
-import Perfume from 'perfume.js';
+jest.mock('web-vitals', () => ({
+	onCLS: jest.fn(),
+	onFCP: jest.fn(),
+	onFID: jest.fn(),
+	onLCP: jest.fn(),
+	onTTFB: jest.fn()
+}));
+import {onCLS, onFCP, onFID, onLCP, onTTFB} from 'web-vitals';
 
 // Mock global performance metrics
 Performance.prototype.getEntriesByType = jest.fn().mockReturnValue([
@@ -53,15 +57,28 @@ describe('src/client/trackers/realUserMonitoringForPerformance', () => {
 			realUserMonitoringForPerformance();
 		});
 
-		it('creates a Perfume instance with a custom analytics tracker', () => {
-			expect(Perfume).toHaveBeenCalledTimes(1);
-			const perfumeOptions = Perfume.mock.calls[0][0];
-			expect(typeof perfumeOptions).toBe('object');
-			expect(typeof perfumeOptions.analyticsTracker).toBe('function');
+		it('listens to metrics with the web-vitals package', () => {
+			expect(onCLS).toHaveBeenCalledTimes(1);
+			expect(typeof onCLS.mock.calls[0][0]).toBe('function');
+			expect(onFCP).toHaveBeenCalledTimes(1);
+			expect(typeof onFCP.mock.calls[0][0]).toBe('function');
+			expect(onFID).toHaveBeenCalledTimes(1);
+			expect(typeof onFID.mock.calls[0][0]).toBe('function');
+			expect(onLCP).toHaveBeenCalledTimes(1);
+			expect(typeof onLCP.mock.calls[0][0]).toBe('function');
+			expect(onTTFB).toHaveBeenCalledTimes(1);
+			expect(typeof onTTFB.mock.calls[0][0]).toBe('function');
 		});
 
-		describe('analyticsTracker(options)', () => {
-			let analyticsTracker;
+		it('uses the same handler for all metrics', () => {
+			expect(onCLS.mock.calls[0][0] === onFCP.mock.calls[0][0]).toBe(true);
+			expect(onCLS.mock.calls[0][0] === onFID.mock.calls[0][0]).toBe(true);
+			expect(onCLS.mock.calls[0][0] === onLCP.mock.calls[0][0]).toBe(true);
+			expect(onCLS.mock.calls[0][0] === onTTFB.mock.calls[0][0]).toBe(true);
+		});
+
+		describe('recordMetric(metric)', () => {
+			let recordMetric;
 			let oldConsole;
 
 			beforeEach(() => {
@@ -69,7 +86,7 @@ describe('src/client/trackers/realUserMonitoringForPerformance', () => {
 				// make it hard to read the test output
 				oldConsole = global.console;
 				global.console = {log: jest.fn()};
-				analyticsTracker = Perfume.mock.calls[0][0].analyticsTracker;
+				recordMetric = onCLS.mock.calls[0][0];
 			});
 
 			afterEach(() => {
@@ -78,7 +95,7 @@ describe('src/client/trackers/realUserMonitoringForPerformance', () => {
 
 			describe('when only one metric type is sent', () => {
 				beforeEach(() => {
-					analyticsTracker({ metricName: 'fid', data: 13.7 });
+					recordMetric({ name: 'FID', value: 13.7 });
 				});
 
 				it('does not broadcast an o-tracking event', () => {
@@ -88,13 +105,11 @@ describe('src/client/trackers/realUserMonitoringForPerformance', () => {
 
 			describe('when all metrics are sent', () => {
 				beforeEach(() => {
-					analyticsTracker({ metricName: 'fid', data: 13.7 });
-					analyticsTracker({ metricName: 'lcp', data: 13.7 });
-					analyticsTracker({ metricName: 'ttfb', data: 13.7 });
-					analyticsTracker({ metricName: 'fp', data: 13.7 });
-					analyticsTracker({ metricName: 'fcp', data: 13.7 });
-					analyticsTracker({ metricName: 'cls', data: 13.7 });
-					analyticsTracker({ metricName: 'tbt', data: 13.7 });
+					recordMetric({ name: 'FID', value: 13.7 });
+					recordMetric({ name: 'LCP', value: 13.7 });
+					recordMetric({ name: 'TTFB', value: 13.7 });
+					recordMetric({ name: 'FCP', value: 13.7 });
+					recordMetric({ name: 'CLS', value: 13.7 });
 				});
 
 				it('broadcasts an o-tracking event with the formatted metrics data', () => {
@@ -106,7 +121,7 @@ describe('src/client/trackers/realUserMonitoringForPerformance', () => {
 
 				describe('when any one of the metrics are sent a second time', () => {
 					beforeEach(() => {
-						analyticsTracker({ metricName: 'fid', data: 13.7 });
+						recordMetric({ name: 'FID', value: 13.7 });
 					});
 
 					it('does not broadcast a second o-tracking event', () => {
@@ -120,13 +135,21 @@ describe('src/client/trackers/realUserMonitoringForPerformance', () => {
 		describe('when the seed is not in the sample', () => {
 
 			beforeEach(() => {
-				Perfume.mockReset();
+				onCLS.mockReset();
+				onFCP.mockReset();
+				onFID.mockReset();
+				onLCP.mockReset();
+				onTTFB.mockReset();
 				seedIsInSample.mockReturnValue(false);
 				realUserMonitoringForPerformance();
 			});
 
-			it('does not create a Perfume instance', () => {
-				expect(Perfume).toHaveBeenCalledTimes(0);
+			it('does not listen for performance metrics', () => {
+				expect(onCLS).toHaveBeenCalledTimes(0);
+				expect(onFCP).toHaveBeenCalledTimes(0);
+				expect(onFID).toHaveBeenCalledTimes(0);
+				expect(onLCP).toHaveBeenCalledTimes(0);
+				expect(onTTFB).toHaveBeenCalledTimes(0);
 			});
 
 		});
@@ -134,13 +157,21 @@ describe('src/client/trackers/realUserMonitoringForPerformance', () => {
 		describe('when no "navigation" performance entries are available', () => {
 
 			beforeEach(() => {
-				Perfume.mockReset();
+				onCLS.mockReset();
+				onFCP.mockReset();
+				onFID.mockReset();
+				onLCP.mockReset();
+				onTTFB.mockReset();
 				Performance.prototype.getEntriesByType.mockReturnValue([]);
 				realUserMonitoringForPerformance();
 			});
 
-			it('does not create a Perfume instance', () => {
-				expect(Perfume).toHaveBeenCalledTimes(0);
+			it('does not listen for performance metrics', () => {
+				expect(onCLS).toHaveBeenCalledTimes(0);
+				expect(onFCP).toHaveBeenCalledTimes(0);
+				expect(onFID).toHaveBeenCalledTimes(0);
+				expect(onLCP).toHaveBeenCalledTimes(0);
+				expect(onTTFB).toHaveBeenCalledTimes(0);
 			});
 
 		});

--- a/src/client/trackers/realUserMonitoringForPerformance.js
+++ b/src/client/trackers/realUserMonitoringForPerformance.js
@@ -94,7 +94,7 @@ export const realUserMonitoringForPerformance = ({ sampleRate } = {}) => {
 		}
 	});
 
-	onCLS(recordMetric);
+	onCLS(recordMetric, { reportAllChanges: true });
 	onFCP(recordMetric);
 	onFID(recordMetric);
 	onLCP(recordMetric);

--- a/src/client/trackers/realUserMonitoringForPerformance.js
+++ b/src/client/trackers/realUserMonitoringForPerformance.js
@@ -76,7 +76,7 @@ export const realUserMonitoringForPerformance = ({ sampleRate } = {}) => {
 		} else if (metricName === 'fcp'){
 			context.firstContentfulPaint = Math.round(data);
 		} else if (metricName === 'cls') {
-			context.cumulativeLayoutShift = data;
+			context.cumulativeLayoutShift = Number(data.toFixed(4));
 		}
 
 		context.url = window.document.location.href || null;


### PR DESCRIPTION
This switches us over to Google Web Vitals. I decided to rewrite this
instead of using #87 for a couple of reasons:

  1. There are some broader format changes in that PR which made it
     difficult to reason about the differences between the two libs.
     `src/client/trackers/realUserMonitoringForPerformance.js` has
     28 rather than 99 changes.

  2. There's been a new major version of the `web-vitals` package since
     the old PR was written.

  3. I wanted to try out the experimental metrics so that we had a more
     complete comparison to Perfume: `onFCP` and `onTTFB`.

## Stuff to review

I still think it's worth reviewing the code at this stage because it's a
nice direct comparison between libraries and any changes I need to
make will probably make the diff less readable.

I think the best starting point for a review would be [the library code](https://github.com/Financial-Times/n-tracking/pull/104/files#diff-c0171c0e937d523c7abd048bea00fcffea0250603bf988bb8d3216a3ea9f3bc1)
rather than the tests (which appear first in the changed files).

## Manual testing results

After some manual testing I pushed another commit, because we
weren't ever sending a tracking event. This is now working and
these are the results (current n-metrics vs this branch):

```yml
n-tracking@5.2.0:
  action: "performance"
  category: "page"
  cumulativeLayoutShift: 0.0718
  domComplete: 0
  domInteractive: 612
  firstContentfulPaint: 412
  firstInputDelay: 6
  firstPaint: 412
  largestContentfulPaint: 635
  timeToFirstByte: 193
  totalBlockingTime: 4
  url: "http://localhost:3000/"

n-tracking@#switch-to-web-vitals:
  action: "performance"
  category: "page"
  cumulativeLayoutShift: 0.06990480437992125
  domComplete: 0
  domInteractive: 612
  firstContentfulPaint: 467
  firstInputDelay: 3
  largestContentfulPaint: 609
  timeToFirstByte: 189
  url: "http://localhost:3000/"
```

## Possible further work

  - [x] ~Should we limit `cumulativeLayoutShift` to four decimal points?
    [Caroline's branch does this](https://github.com/Financial-Times/n-tracking/pull/87/files#diff-c0171c0e937d523c7abd048bea00fcffea0250603bf988bb8d3216a3ea9f3bc1R63-R64) so it's not a lot of work~ Yes

---

Relates-To: [FTDCS-294](https://financialtimes.atlassian.net/browse/FTDCS-294)