### PR TITLE
update version of o-tracking

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "MIT",
       "dependencies": {
         "@financial-times/o-grid": "^5.0.0",
-        "@financial-times/o-tracking": "^4.0.0",
+        "@financial-times/o-tracking": "^4.5.0",
         "@financial-times/o-viewport": "^4.0.0",
         "ready-state": "^2.0.5",
         "web-vitals": "^3.0.0"
@@ -2220,9 +2220,9 @@
       }
     },
     "node_modules/@financial-times/o-tracking": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@financial-times/o-tracking/-/o-tracking-4.2.0.tgz",
-      "integrity": "sha512-SWuzLPWSVOqtqmceUp5z3npaD7GDbzKc20mHHIi5wy51cUzHz/SG4XeooHa999jfIJ/es297lu168om3PZglWg==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@financial-times/o-tracking/-/o-tracking-4.5.0.tgz",
+      "integrity": "sha512-gPnAmMPqlYWf8xXNJkAYKQMpEWvHpjxajB4YnadbGhOGl2Zy8y5LJJqyzsfpqoBh51P7VDIc7yBF+A7fgaymYw==",
       "dependencies": {
         "ftdomdelegate": "^5"
       },
@@ -16897,9 +16897,9 @@
       }
     },
     "@financial-times/o-tracking": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@financial-times/o-tracking/-/o-tracking-4.2.0.tgz",
-      "integrity": "sha512-SWuzLPWSVOqtqmceUp5z3npaD7GDbzKc20mHHIi5wy51cUzHz/SG4XeooHa999jfIJ/es297lu168om3PZglWg==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@financial-times/o-tracking/-/o-tracking-4.5.0.tgz",
+      "integrity": "sha512-gPnAmMPqlYWf8xXNJkAYKQMpEWvHpjxajB4YnadbGhOGl2Zy8y5LJJqyzsfpqoBh51P7VDIc7yBF+A7fgaymYw==",
       "requires": {
         "ftdomdelegate": "^5"
       }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@financial-times/o-grid": "^5.0.0",
-    "@financial-times/o-tracking": "^4.0.0",
+    "@financial-times/o-tracking": "^4.5.0",
     "@financial-times/o-viewport": "^4.0.0",
     "ready-state": "^2.0.5",
     "web-vitals": "^3.0.0"


### PR DESCRIPTION
Issue: 
[HIVE-999](https://financialtimes.atlassian.net/browse/HIVE-999)
### What
Updated o-tracking to newer version that support nested objects.
This is tested in next-home-page with pre-release version: v6.1.0-beta.1


[HIVE-999]: https://financialtimes.atlassian.net/browse/HIVE-999?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ