### PR TITLE
ADSDEV-1307: Make oTracking instance available on the window client side

### DIFF
--- a/src/client/index.js
+++ b/src/client/index.js
@@ -40,6 +40,7 @@ export function init ({ appContext, extraContext, pageViewContext }) {
 	oTracking.click.init('cta');
 
 	if (window.oTracking) {
+		// eslint-disable-next-line no-console
 		console.warn("An oTracking instance already exists on window, skipping", { currentInstance: window.oTracking, ourInstance: oTracking });
 	} else {
 		window.oTracking = oTracking;


### PR DESCRIPTION
We are changing how ads are served on FT.com. 

Ad specific behaviour will now be served externally rather than being bundled with the consuming app through `advertising/ads-display` as it's currently done. 

Part of this gradual change is to replicate current ad features to be compatible with this new way of serving ads on ft.com

The o-tracking instance is used by ads to improve user targeting, and notably, the rootID of the page is sent with ad request for matching and Ad operations purposes. 

Rather than including o-tracking into the Ads package [as it's currently done](https://github.com/Financial-Times/advertising/blob/main/packages/display/src/client/utils.js#L2), we want to make use of what's already downloaded and available on the consuming app. So that the root id can be retrieved and sent with the ad requests by calling `window.oTracking.getRootID()`. 

Since n-tracking is installed to all ft.com pages, it makes sense to make this change here rather than exporting the `oTracking` instance on the window for every app that makes up ft.com, but let me know if there's any concerns with the approach

 @jkerr321 @kavanagh @rowanmanning I added you to the review as you might have counterpoints to the approach, I'm very much open to doing something different if you think it could be problematic.