### PR TITLE
ADSDEV-1243: Send cookies data on page view event

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@financial-times/o-grid": "^5.0.0",
         "@financial-times/o-tracking": "^4.5.0",
         "@financial-times/o-viewport": "^4.0.0",
+        "@financial-times/privacy-us-privacy": "^1.0.0",
         "ready-state": "^2.0.5",
         "web-vitals": "^3.0.0"
       },
@@ -2241,6 +2242,19 @@
       "integrity": "sha512-dNB52EYnrfujG6V6B1foxCRWjgklsDc7KIEC0LOoUmXBIPXW258efzXMOKeK8ElVo3P2REjK+VOcTxJXnKuP+A==",
       "dependencies": {
         "@financial-times/o-utils": "^1.0.0"
+      }
+    },
+    "node_modules/@financial-times/privacy-legislation-client": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@financial-times/privacy-legislation-client/-/privacy-legislation-client-1.0.0.tgz",
+      "integrity": "sha512-tnF8/g4u70sHmay46FMONpeXqy7K/DckcLtvfda7WjysgdbIGmw1baZovNMXdPypfbJZeCV3eQO9xKcRySubJA=="
+    },
+    "node_modules/@financial-times/privacy-us-privacy": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@financial-times/privacy-us-privacy/-/privacy-us-privacy-1.0.0.tgz",
+      "integrity": "sha512-iQS8u4sifeqczVOkaSyrVZUny8/Augc9LJs6/rESE1v41grU9BxpnCHk1v6l3NRCq+Rb4uzeB4TCNtkWaDhcQw==",
+      "dependencies": {
+        "@financial-times/privacy-legislation-client": "^1.0.0"
       }
     },
     "node_modules/@financial-times/secret-squirrel": {
@@ -16915,6 +16929,19 @@
       "integrity": "sha512-dNB52EYnrfujG6V6B1foxCRWjgklsDc7KIEC0LOoUmXBIPXW258efzXMOKeK8ElVo3P2REjK+VOcTxJXnKuP+A==",
       "requires": {
         "@financial-times/o-utils": "^1.0.0"
+      }
+    },
+    "@financial-times/privacy-legislation-client": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@financial-times/privacy-legislation-client/-/privacy-legislation-client-1.0.0.tgz",
+      "integrity": "sha512-tnF8/g4u70sHmay46FMONpeXqy7K/DckcLtvfda7WjysgdbIGmw1baZovNMXdPypfbJZeCV3eQO9xKcRySubJA=="
+    },
+    "@financial-times/privacy-us-privacy": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@financial-times/privacy-us-privacy/-/privacy-us-privacy-1.0.0.tgz",
+      "integrity": "sha512-iQS8u4sifeqczVOkaSyrVZUny8/Augc9LJs6/rESE1v41grU9BxpnCHk1v6l3NRCq+Rb4uzeB4TCNtkWaDhcQw==",
+      "requires": {
+        "@financial-times/privacy-legislation-client": "^1.0.0"
       }
     },
     "@financial-times/secret-squirrel": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@financial-times/o-grid": "^5.0.0",
     "@financial-times/o-tracking": "^4.5.0",
     "@financial-times/o-viewport": "^4.0.0",
+    "@financial-times/privacy-us-privacy": "^1.0.0",
     "ready-state": "^2.0.5",
     "web-vitals": "^3.0.0"
   },

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -3,6 +3,7 @@ import getUserData from './tracking/getUserData';
 import getQueryParams from './tracking/getQueryParams';
 import getErrorPageParams from './tracking/getErrorPageParams';
 import transformContextData from './utils/transformContextData';
+import getConsentDataFromCookies from "./utils/getConsentDataFromCookies";
 
 export const SPOOR_API_INGEST_URL = 'https://spoor-api.ft.com/ingest';
 
@@ -29,10 +30,10 @@ export function init ({ appContext, extraContext, pageViewContext }) {
 	// Automatically trigger the page view event unless we're in an iframe
 	if (window === window.top || window.location.hostname === 'errors-next.ft.com') {
 		const errorPageParams = getErrorPageParams();
-
 		oTracking.page({
 			...errorPageParams,
 			...pageViewContext,
+			consents: { ...getConsentDataFromCookies() } ,
 		});
 	}
 

--- a/src/client/utils/getConsentDataFromCookies.js
+++ b/src/client/utils/getConsentDataFromCookies.js
@@ -1,0 +1,44 @@
+import { getCookie } from "./getCookie";
+import { getUsPrivacyForTracking } from "@financial-times/privacy-us-privacy";
+
+export default function getConsentDataFromCookies() {
+	const usprivacy = getUsPrivacyForTracking();
+	const rawConsentCookie = getCookie("FTConsent");
+
+	if (!rawConsentCookie) {
+		return {
+			behavioral: false,
+			demographic: false,
+			programmatic: false,
+			all: false,
+			usprivacy,
+		};
+	}
+
+	const { behaviouraladsOnsite, demographicadsOnsite, programmaticadsOnsite } = parseFTConsentCookie(rawConsentCookie);
+
+	return {
+		behavioral: behaviouraladsOnsite,
+		demographic: demographicadsOnsite,
+		programmatic: programmaticadsOnsite,
+		all: behaviouraladsOnsite && demographicadsOnsite && programmaticadsOnsite,
+		usprivacy,
+	};
+}
+
+function parseFTConsentCookie(value) {
+	if (!value || !value.length) {
+		return {
+			behaviouraladsOnsite: false,
+			demographicadsOnsite: false,
+			programmaticadsOnsite: false,
+		};
+	}
+
+	return Object.fromEntries(
+		decodeURIComponent(value)
+			.split(",")
+			.map((item) => item.split(":"))
+			.map(([key, value]) => [key, value === "on" ? true : false])
+	);
+}


### PR DESCRIPTION
This update gets data from the cookie before sending the page view event to spoor as per [this ticket ](https://financialtimes.atlassian.net/jira/software/c/projects/ADSDEV/boards/803?modal=detail&selectedIssue=ADSDEV-1243)

The approach is synchronous and has the advantage to not breaking the workflow of consumers of n-tracking.

The downside of this approach is that the data we're sending relies on what we have in the browser cookies, it could get out of date until navigation happens which is when the cookies are updated.


This work will eventually be followed by a change to add this consent data to more events and capture consent changes if a user clicks the cookie banner while on a page.

How to test the change: 

- install next-home-page locally (these steps can be done on any other consumer of n-tracking like article, stream, search)
- in `apps/home-page/package.json` replace the `@financial-times/n-tracking` to:    
```
"@financial-times/n-tracking": "https://github.com/financial-times/n-tracking.git#ADSDEV-1243-add-privacy-info",
```
- Load the page and go to the network tab then filter by `page:view`
<img width="1204" alt="Screenshot 2023-03-15 at 19 38 11" src="https://user-images.githubusercontent.com/112861262/225409736-d066c903-4cf3-473b-bf62-d398a688c60f.png">
- A new `consents` section will appear in the context containing the user's consent values
