### PR TITLE
Only require latest version of Node tests to pass to publish

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -173,7 +173,7 @@ workflows:
           filters:
             <<: *filters_version_tag
           requires:
-            - test
+            - test-v18.16
 
   renovate-nori-build-test:
     when:


### PR DESCRIPTION
This avoids an issue with the CircleCI workflow where depending on both the Node 16 and Node 18 test jobs to pass meant that we could not attach the workspace to the publish job as the `node_modules` directory in the test jobs conflicted. The downside now is that we will automatically publish the package even if the Node 16 tests fail. I don't think CircleCI provides any way to work around this when testing mutiple Node versions concurrently (there's no way to select which job to attach a workspace from, for instance).