### PR TITLE
Add 'excludeAttentionTime' and 'excludeScrollDepth' options to page attention tracker

### DIFF
--- a/docs/page-attention.md
+++ b/docs/page-attention.md
@@ -55,10 +55,12 @@ if (flags.get('pageAttentionTracking')) {
 
 The `pageAttention()` method accepts an options object with the following properties:
 
-| Option | Required | Type    | Description                                               |
-|--------|----------|---------|-----------------------------------------------------------|
-| target | No       | String  | Target element selector to apply scroll depth markers to. |
-| debug  | No       | Boolean | Enable verbose logs for attention events                  |
+| Option               | Required | Type    | Description                                               |
+|----------------------|----------|---------|-----------------------------------------------------------|
+| target               | No       | String  | Target element selector to apply scroll depth markers to. |
+| debug                | No       | Boolean | Enable verbose logs for attention events                  |
+| excludeAttentionTime | No       | Boolean | Disables attention time tracking                          |
+| excludeScrollDepth   | No       | Boolean | Disables scroll depth tracking                            |
 
 This will initialise two sub-components:
 
@@ -67,6 +69,8 @@ This will initialise two sub-components:
 
 2. ### Scroll depth
     This creates a number of marker elements at equal intervals down the length of the page. The first time a marker moves into the browser's viewport a `page:scrolldepth` event is triggered. Each scroll depth event also includes the current attention time.
+
+If only one of these features is needed, use the `excludeAttentionTime` or `excludeScrollDepth` options to achieve this.
 
 
 ## More details

--- a/src/client/trackers/pageAttention.js
+++ b/src/client/trackers/pageAttention.js
@@ -1,34 +1,52 @@
-import { broadcast } from '../broadcast';
-import ScrollDepth from './page-attention/ScrollDepth';
-import AttentionTime from './page-attention/AttentionTime';
+import { broadcast } from "../broadcast";
+import ScrollDepth from "./page-attention/ScrollDepth";
+import AttentionTime from "./page-attention/AttentionTime";
+
+const defaultOptions = {
+	excludeAttentionTime: false,
+	excludeScrollDepth: false,
+};
 
 // TODO: The tracking event data for the `page:interaction` and `page:scrolldepth`
 // events is needlessly different. We should work with the data team to align it.
 export const pageAttention = (options = {}) => {
-	const onExit = (attentionTime) => {
-		broadcast('oTracking.event', {
-			category: 'page',
-			action: 'interaction',
-			context: {
-				attention: {
-					total: attentionTime
-				}
-			}
-		});
-	};
+	const optionsWithDefaults = { ...defaultOptions, ...options };
 
-	const attention = new AttentionTime({ ...options, onExit });
+	let attention;
 
-	const onScroll = (scrollDepth) => {
-		broadcast('oTracking.event', {
-			category: 'page',
-			action: 'scrolldepth',
-			meta: {
+	if (!optionsWithDefaults.excludeAttentionTime) {
+		const onExit = (attentionTime) => {
+			broadcast("oTracking.event", {
+				category: "page",
+				action: "interaction",
+				context: {
+					attention: {
+						total: attentionTime,
+					},
+				},
+			});
+		};
+
+		attention = new AttentionTime({ ...optionsWithDefaults, onExit });
+	}
+
+	if (!optionsWithDefaults.excludeScrollDepth) {
+		const onScroll = (scrollDepth) => {
+			const meta = {
 				percentagesViewed: scrollDepth,
-				attention: attention.getAttentionTime()
-			}
-		});
-	};
+			};
 
-	new ScrollDepth({ ...options, onScroll });
+			if (attention) {
+				meta.attention = attention.getAttentionTime();
+			}
+
+			broadcast("oTracking.event", {
+				category: "page",
+				action: "scrolldepth",
+				meta,
+			});
+		};
+
+		new ScrollDepth({ ...optionsWithDefaults, onScroll });
+	}
 };


### PR DESCRIPTION
I'd like to be able to use this package's really useful scroll depth tracking without attention time tracking.

For pages that don't just show a single piece of content, e.g. a menu page or search results page, this 'attention time' metric isn't really relevant, as it's calculated according to word count.

This PR adds the ability to enable or disable either 'feature' of the page attention tracker offered by this package.

My team (#professional-lifecycle-experience) are about to release a trial for a new search page (https://enhanced-search.ft.com/?q=france), and we'd like to be able to record how far users scroll down the search results page, for both this new page, and the current search page.

Of course we can already do this with the current page attention tracker, but this extra 'attention' property included by the `PageAttention` feature interferes with our analytics pipeline.