### PR TITLE
Include INP in metrics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@financial-times/o-viewport": "^4.0.0",
         "@financial-times/privacy-us-privacy": "^1.0.0",
         "ready-state": "^2.0.5",
-        "web-vitals": "^3.0.0"
+        "web-vitals": "^3.4.0"
       },
       "devDependencies": {
         "@babel/core": "^7.5.5",
@@ -15026,9 +15026,9 @@
       }
     },
     "node_modules/web-vitals": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-3.0.1.tgz",
-      "integrity": "sha512-n8LgBynM5BU4C8ZMiTWPu6zbv31AfPnuNXEjWClvPWD5g8h2WkcecR0EtAiQaiMcj1iG0LADyHndR+MKYu5Zog=="
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-3.4.0.tgz",
+      "integrity": "sha512-n9fZ5/bG1oeDkyxLWyep0eahrNcPDF6bFqoyispt7xkW0xhDzpUBTgyDKqWDi1twT0MgH4HvvqzpUyh0ZxZV4A=="
     },
     "node_modules/webidl-conversions": {
       "version": "4.0.2",
@@ -26901,9 +26901,9 @@
       }
     },
     "web-vitals": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-3.0.1.tgz",
-      "integrity": "sha512-n8LgBynM5BU4C8ZMiTWPu6zbv31AfPnuNXEjWClvPWD5g8h2WkcecR0EtAiQaiMcj1iG0LADyHndR+MKYu5Zog=="
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-3.4.0.tgz",
+      "integrity": "sha512-n9fZ5/bG1oeDkyxLWyep0eahrNcPDF6bFqoyispt7xkW0xhDzpUBTgyDKqWDi1twT0MgH4HvvqzpUyh0ZxZV4A=="
     },
     "webidl-conversions": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@financial-times/o-viewport": "^4.0.0",
     "@financial-times/privacy-us-privacy": "^1.0.0",
     "ready-state": "^2.0.5",
-    "web-vitals": "^3.0.0"
+    "web-vitals": "^3.4.0"
   },
   "peerDependencies": {
     "react": ">=16.9.0 <19.0.0"

--- a/src/client/trackers/__test__/__snapshots__/realUserMonitoring.spec.js.snap
+++ b/src/client/trackers/__test__/__snapshots__/realUserMonitoring.spec.js.snap
@@ -9,6 +9,7 @@ Object {
   "domInteractive": 679,
   "firstContentfulPaint": 14,
   "firstInputDelay": 14,
+  "interactionToNextPaint": 14,
   "largestContentfulPaint": 14,
   "timeToFirstByte": 14,
   "url": "http://localhost/",

--- a/src/client/trackers/__test__/realUserMonitoring.spec.js
+++ b/src/client/trackers/__test__/realUserMonitoring.spec.js
@@ -30,9 +30,10 @@ jest.mock('web-vitals', () => ({
 	onFCP: jest.fn(),
 	onFID: jest.fn(),
 	onLCP: jest.fn(),
-	onTTFB: jest.fn()
+	onTTFB: jest.fn(),
+	onINP: jest.fn(),
 }));
-import {onCLS, onFCP, onFID, onLCP, onTTFB} from 'web-vitals';
+import { onCLS, onFCP, onFID, onLCP, onTTFB, onINP } from 'web-vitals';
 
 // Mock global performance metrics
 Performance.prototype.getEntriesByType = jest.fn().mockReturnValue([
@@ -65,6 +66,8 @@ describe('src/client/trackers/realUserMonitoringForPerformance', () => {
 			expect(typeof onLCP.mock.calls[0][0]).toBe('function');
 			expect(onTTFB).toHaveBeenCalledTimes(1);
 			expect(typeof onTTFB.mock.calls[0][0]).toBe('function');
+			expect(onINP).toHaveBeenCalledTimes(1);
+			expect(typeof onINP.mock.calls[0][0]).toBe('function');
 		});
 
 		it('uses the same handler for all metrics', () => {
@@ -73,6 +76,7 @@ describe('src/client/trackers/realUserMonitoringForPerformance', () => {
 			expect(onFID.mock.calls[0][0]).toStrictEqual(clsHandler);
 			expect(onLCP.mock.calls[0][0]).toStrictEqual(clsHandler);
 			expect(onTTFB.mock.calls[0][0]).toStrictEqual(clsHandler);
+			expect(onINP.mock.calls[0][0]).toStrictEqual(clsHandler);
 		});
 
 		describe('recordMetric(metric)', () => {
@@ -144,6 +148,7 @@ describe('src/client/trackers/realUserMonitoringForPerformance', () => {
 				onFID.mockReset();
 				onLCP.mockReset();
 				onTTFB.mockReset();
+				onINP.mockReset();
 				seedIsInSample.mockReturnValue(false);
 				realUserMonitoringForPerformance();
 			});
@@ -154,6 +159,7 @@ describe('src/client/trackers/realUserMonitoringForPerformance', () => {
 				expect(onFID).toHaveBeenCalledTimes(0);
 				expect(onLCP).toHaveBeenCalledTimes(0);
 				expect(onTTFB).toHaveBeenCalledTimes(0);
+				expect(onINP).toHaveBeenCalledTimes(0);
 			});
 
 		});
@@ -166,6 +172,7 @@ describe('src/client/trackers/realUserMonitoringForPerformance', () => {
 				onFID.mockReset();
 				onLCP.mockReset();
 				onTTFB.mockReset();
+				onINP.mockReset();
 				Performance.prototype.getEntriesByType.mockReturnValue([]);
 				realUserMonitoringForPerformance();
 			});
@@ -176,6 +183,7 @@ describe('src/client/trackers/realUserMonitoringForPerformance', () => {
 				expect(onFID).toHaveBeenCalledTimes(0);
 				expect(onLCP).toHaveBeenCalledTimes(0);
 				expect(onTTFB).toHaveBeenCalledTimes(0);
+				expect(onINP).toHaveBeenCalledTimes(0);
 			});
 
 		});

--- a/src/client/trackers/__test__/realUserMonitoring.spec.js
+++ b/src/client/trackers/__test__/realUserMonitoring.spec.js
@@ -112,6 +112,7 @@ describe('src/client/trackers/realUserMonitoringForPerformance', () => {
 					recordMetric({ name: 'TTFB', value: 13.7 });
 					recordMetric({ name: 'FCP', value: 13.7 });
 					recordMetric({ name: 'CLS', value: 13.76539 });
+					recordMetric({ name: 'INP', value: 13.7 });
 				});
 
 				it('broadcasts an o-tracking event with the formatted metrics data', () => {

--- a/src/client/trackers/realUserMonitoringForPerformance.js
+++ b/src/client/trackers/realUserMonitoringForPerformance.js
@@ -1,8 +1,9 @@
-import {onCLS, onFCP, onFID, onLCP, onTTFB} from 'web-vitals';
+import { onCLS, onFCP, onFID, onLCP, onTTFB, onINP } from 'web-vitals';
 import readyState from 'ready-state';
 import { broadcast } from '../broadcast';
 import { seedIsInSample } from '../utils/seedIsInSample';
 import { getSpoorId } from '../utils/getSpoorId';
+
 
 // @see "Important metrics to measure" https://web.dev/metrics
 const requiredMetrics = [
@@ -12,7 +13,8 @@ const requiredMetrics = [
 	'largestContentfulPaint',
 	'firstInputDelay',
 	'cumulativeLayoutShift',
-	'firstContentfulPaint'
+	'firstContentfulPaint',
+	'interactionToNextPaint'
 ];
 
 const defaultSampleRate = 10;
@@ -73,10 +75,12 @@ export const realUserMonitoringForPerformance = ({ sampleRate } = {}) => {
 			context.largestContentfulPaint = Math.round(data);
 		} else if (metricName === 'ttfb') {
 			context.timeToFirstByte = Math.round(data);
-		} else if (metricName === 'fcp'){
+		} else if (metricName === 'fcp') {
 			context.firstContentfulPaint = Math.round(data);
 		} else if (metricName === 'cls') {
 			context.cumulativeLayoutShift = Number(data.toFixed(4));
+		} else if (metricName === 'inp') {
+			context.interactionToNextPaint = Math.round(data);
 		}
 
 		context.url = window.document.location.href || null;
@@ -99,4 +103,5 @@ export const realUserMonitoringForPerformance = ({ sampleRate } = {}) => {
 	onFID(recordMetric);
 	onLCP(recordMetric);
 	onTTFB(recordMetric);
+	onINP(recordMetric);
 };


### PR DESCRIPTION
"INP is no longer experimental. Learn about Chrome's plan to make it a Core Web Vital in 2024." - https://web.dev/inp-cwv/

This change adds INP as a metric, so we'll track this. The earlier we capture this data the better, and it will be good to start ahead of 2024's change so our SEO doesn't take a hit.