### PR TITLE
Add display size to tracking

### DIFF
--- a/src/client/index.js
+++ b/src/client/index.js
@@ -22,7 +22,13 @@ export function init ({ appContext, extraContext, pageViewContext }) {
 		// Using the Beacon API ensures that no tracking event data is lost
 		// when the document is being unloaded, which happens when navigating
 		// to a different page.
-		useSendBeacon: true
+		useSendBeacon: true,
+		device: {
+			dimensions: {
+				width: window.screen.width,
+				height: window.screen.height
+			}
+		}
 	};
 
 	oTracking.init(options);


### PR DESCRIPTION
The Ads Growth team would like to have fine-grained information about the screen size our users have. 

This PR adds the device / dimensions object to the tracking per [o-tracking's structure.](https://github.com/Financial-Times/origami/blob/main/libraries/o-tracking/docs/event.md)

We considered `window.innerX` and `Math.max(window.screen.x, window.innerX);` but the need is to target the full browser window size within a screen, so we settled on `window.screen.x`.