### PR TITLE
ci-2846 bump o-tracking

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@financial-times/ads-personalised-consent": "^5.3.3",
         "@financial-times/o-grid": "^5.0.0",
-        "@financial-times/o-tracking": "^4.7.0",
+        "@financial-times/o-tracking": "^4.8.0",
         "@financial-times/o-viewport": "^4.0.0",
         "@financial-times/privacy-us-privacy": "^2.1.0",
         "ready-state": "^2.0.5",
@@ -2305,9 +2305,9 @@
       }
     },
     "node_modules/@financial-times/o-tracking": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@financial-times/o-tracking/-/o-tracking-4.7.0.tgz",
-      "integrity": "sha512-jvnEkuJEXgKqZYUWomRxJ24bI9gnRmK6m6eyyiyt0imorpyxIuTWgaW9b1sYQizPdsiHiXfvwMtbVYEhdAL+wg==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@financial-times/o-tracking/-/o-tracking-4.8.0.tgz",
+      "integrity": "sha512-MhnPQ1rsPAKPEDs1MIm824tJ/2njQqvXnRJKd6borQxuHhdAAE9HjOZfZvgv8fmKPE291RLof4ppbdFyX5gmPQ==",
       "dependencies": {
         "ftdomdelegate": "^5"
       },

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "dependencies": {
     "@financial-times/ads-personalised-consent": "^5.3.3",
     "@financial-times/o-grid": "^5.0.0",
-    "@financial-times/o-tracking": "^4.7.0",
+    "@financial-times/o-tracking": "^4.8.0",
     "@financial-times/o-viewport": "^4.0.0",
     "@financial-times/privacy-us-privacy": "^2.1.0",
     "ready-state": "^2.0.5",


### PR DESCRIPTION
Bump o-tracking to v.4.8.0, which allows us to pass in 'custom'  to component views context, in order to support things like `context.custom.0.name` and `context.custom.0.value` as specified in https://docs.google.com/spreadsheets/d/16d2-uDM8rhz1wSKOkoupcpPDRFQ8AtY1GxVJpt74vY4/edit?gid=1318706009#gid=1318706009