### PR TITLE
Upgrading the React peer dependency to include version 19

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
         "npm": "7.x || 8.x || 9.x"
       },
       "peerDependencies": {
-        "react": ">=16.9.0 <19.0.0"
+        "react": ">=16.9.0 <20.0.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "web-vitals": "^3.4.0"
   },
   "peerDependencies": {
-    "react": ">=16.9.0 <19.0.0"
+    "react": ">=16.9.0 <20.0.0"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
Upgrading the React peer dependency to include React 19 to update [g-components](https://github.com/Financial-Times/g-components) to react version 19. 

