### PR TITLE
LIF-677: Bump o-tracking to 4.10.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@financial-times/ads-personalised-consent": "^5.3.3",
         "@financial-times/o-grid": "^5.0.0",
-        "@financial-times/o-tracking": "^4.8.0",
+        "@financial-times/o-tracking": "^4.10.0",
         "@financial-times/o-viewport": "^4.0.0",
         "@financial-times/privacy-us-privacy": "^2.1.0",
         "ready-state": "^2.0.5",
@@ -2305,9 +2305,10 @@
       }
     },
     "node_modules/@financial-times/o-tracking": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/@financial-times/o-tracking/-/o-tracking-4.8.0.tgz",
-      "integrity": "sha512-MhnPQ1rsPAKPEDs1MIm824tJ/2njQqvXnRJKd6borQxuHhdAAE9HjOZfZvgv8fmKPE291RLof4ppbdFyX5gmPQ==",
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/@financial-times/o-tracking/-/o-tracking-4.10.0.tgz",
+      "integrity": "sha512-RENBI0jKTXp62nYANi1D8m5YV6d/3db/mfXupz5HVToAS/eLCGtYbFdDCrsbWqfaoITsObknV8eUpmVkRYIbNg==",
+      "license": "MIT",
       "dependencies": {
         "ftdomdelegate": "^5"
       },

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "dependencies": {
     "@financial-times/ads-personalised-consent": "^5.3.3",
     "@financial-times/o-grid": "^5.0.0",
-    "@financial-times/o-tracking": "^4.8.0",
+    "@financial-times/o-tracking": "^4.10.0",
     "@financial-times/o-viewport": "^4.0.0",
     "@financial-times/privacy-us-privacy": "^2.1.0",
     "ready-state": "^2.0.5",


### PR DESCRIPTION
Bumps [o-tracking](https://github.com/Financial-Times/origami/commit/0593a57d1a8321e95bfa52a14d1de8a0f1eeedb3) to 4.10.0 

Updates o-tracking from 4.8.0 to 4.10.0